### PR TITLE
Add browser to system properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,36 +39,39 @@ The goal is to build a solid and generic foundation so that Test Automation Engi
 * _[WebDriverManager](https://github.com/bonigarcia/webdrivermanager)_ - Downloads the required driver during runtime. May be configured on `DriverContext` under `/base`
 * _[MockServer](https://www.mock-server.com/) 🐳_ - Enables the ability to mock _http_ requests and responses (check [mocking](#mocking-requests-and-responses) section)
 * _[ExtentReports](https://extentreports.com/)_ - Provides full test reports. Takes screenshots upon test failure by default (check [reports](#reports) section)
-* _[Sonarqube](https://www.sonarqube.org/) 🐳_ - A static analysis tool. Executable through `$ mvn sonar:sonar -Dsonar.host.url=http://<<docker_ip>>:9090`
+* _[SonarQube](https://www.sonarqube.org/) 🐳_ - A static analysis tool. Executable through `$ mvn sonar:sonar -Dsonar.host.url=http://<<docker_ip>>:9090`
 * _[SeleniumGrid](https://github.com/SeleniumHQ/docker-selenium) 🐳_ - Allows to scale the test executing as well as providing the required browser types
 * _[Checkstyle](https://maven.apache.org/plugins/maven-checkstyle-plugin/)_ - Code linter. Executable through `$ mvn validate`
 
-> _🐳 stands for currently dockerized_
+> _🐳 stands for dockerized_
 
 ## Getting Started
 
 ```shell script
 $ git clone https://github.com/sergiomartins8/ui-automation-bootstrap.git
+$ cd ui-automation-bootstrap/
 $ docker-compose up -d
 $ mvn test -Dtestnames=Example
 ```
 
-### Inject runtime properties
+### Runtime properties
 
 Configurable on `pom.xml`
 
 ````shell script
-$ mvn test -Dtestnames=Example [-Dparallel=methods|classes|tests] [-DthreadCount=n] [-Dlistener="utils.listeners.ExampleListener"] [-Denvironment="$env"]
+$ mvn test -Dtestnames=Example [-Dbrowser=chrome|firefox] [-Dparallel=methods|classes|tests] [-DthreadCount=n] [-Dlistener="utils.listeners.ExampleListener"] [-Denvironment="$env"]
 ````
 
 > **testnames** (mandatory) - Tests to be executed (check `testng.xml`)
-
+>
+> **browser** (optional, default `chrome`) - Browser to execute tests
+>
 > **parallel** (optional, default `false`) - Tells testng the method of parallel test execution
-
+>
 > **threadCount** (optional, default `1`) - How many threads to use during test execution
-
+>
 > **listener** (optional, default `MockListener` and `ExtentReportListener`) - Additional listener to be used during test execution (check `testng.xml`)
-
+>
 > **environment** (optional, default `qa`) - Environment configuration to be loaded. However, it's overwritten when `run.tests.local=true`, falling back to default `local`.
 
 ## Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.sergiomartins8</groupId>
     <artifactId>ui-automation-bootstrap</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/test/java/utils/config/ConfigReader.java
+++ b/src/test/java/utils/config/ConfigReader.java
@@ -31,7 +31,7 @@ public final class ConfigReader {
     private static Config localConfiguration() {
         Properties properties = getPropertiesFromResource("config/config.local.properties");
 
-        return new Config.Builder(true, BrowserType.valueOf(properties.getProperty("browser.type")))
+        return new Config.Builder(true, getBrowserType(properties))
                 .withBaseUrl(properties.getProperty("base.url"))
                 .withScreenshots(Boolean.parseBoolean(properties.getProperty("screenshots")))
                 .withHeadless(Boolean.parseBoolean(properties.getProperty("headless")))
@@ -46,7 +46,7 @@ public final class ConfigReader {
 
         Properties properties = getPropertiesFromResource("config/config." + environment + ".properties");
 
-        return new Config.Builder(false, BrowserType.valueOf(properties.getProperty("browser.type")))
+        return new Config.Builder(false, getBrowserType(properties))
                 .withBaseUrl(properties.getProperty("base.url"))
                 .withScreenshots(Boolean.parseBoolean(properties.getProperty("screenshots")))
                 .withHeadless(Boolean.parseBoolean(properties.getProperty("headless")))
@@ -73,5 +73,14 @@ public final class ConfigReader {
             e.printStackTrace();
         }
         return properties;
+    }
+
+    /**
+     * @param properties environment configuration
+     * @return {@link BrowserType} based on system properties or (if null) the environment configuration
+     */
+    private static BrowserType getBrowserType(Properties properties) {
+        return System.getProperty("browser") != null
+                ? BrowserType.valueOf(System.getProperty("browser")) : BrowserType.valueOf(properties.getProperty("browser.type"));
     }
 }


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [ ] This change has been discussed in issue #5 and the solution has been agreed upon with maintainers.

---

**Description:**
The current pull request adds the browser property to the system properties. Therefore, it can be injected during maven life cycle.

e.g. `mvn clean test -Dtestnames=name -Dbrowser=chrome`