### PR TITLE
🐛 Fix firefox integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Features:
 ```shell script
 $ mvn archetype:generate -DarchetypeGroupId=com.github.sergiomartins8 \ 
                          -DarchetypeArtifactId=ui-automation-bootstrap \
-                         -DarchetypeVersion=1.0.0 \
+                         -DarchetypeVersion=1.1.0 \
                          -DgroupId=awesome.group.id \
                          -DartifactId=awesome-template \
                          -Dcheckstyle=true \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,7 @@ services:
     image: jamesdbloom/mockserver:mockserver-5.7.2
     container_name: mockserver
     ports:
-      - "3000:1080"
-      - "3001:1090"
+      - "1080:1080"
 
   selenium-hub:
     image: selenium/hub:3.141
@@ -20,8 +19,6 @@ services:
   chrome:
     image: selenium/node-chrome:3.141
     container_name: chrome
-    ports:
-      - "5900:5900"
     volumes:
       - /dev/shm:/dev/shm
     depends_on:
@@ -33,8 +30,6 @@ services:
   firefox:
     image: selenium/node-firefox:3.141
     container_name: firefox
-    ports:
-      - "5901:5900"
     volumes:
       - /dev/shm:/dev/shm
     depends_on:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.sergiomartins8</groupId>
     <artifactId>ui-automation-bootstrap</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>maven-archetype</packaging>
 
     <name>ui-automation-bootstrap</name>

--- a/src/main/resources/archetype-resources/docker-compose.yaml
+++ b/src/main/resources/archetype-resources/docker-compose.yaml
@@ -37,8 +37,8 @@ services:
     image: jamesdbloom/mockserver:mockserver-5.7.2
     container_name: mockserver
     ports:
-      - "3000:1080"
-      - "3001:1090"
+      - "1080:1080"
+      - "1090:1090"
 #end
 
   selenium-hub:

--- a/src/main/resources/archetype-resources/src/test/java/base/DriverContext.java
+++ b/src/main/resources/archetype-resources/src/test/java/base/DriverContext.java
@@ -17,7 +17,7 @@ import java.net.URL;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 
 /**
- * Holds methods that initialize (and teardown) the required driver; locally or remotely.
+ * Holds methods that initialize and teardown the required driver; locally or remotely.
  * <br>
  * Also, an instance to the {@link Browser} in which browser actions can be performed
  */

--- a/src/main/resources/archetype-resources/src/test/java/base/FrameworkBootstrap.java
+++ b/src/main/resources/archetype-resources/src/test/java/base/FrameworkBootstrap.java
@@ -1,41 +1,23 @@
 package ${package}.base;
 
-#if (${mockserver} == 'true')
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
-import ${package}.utils.config.CustomConfiguration;
-#end
 import ${package}.utils.logging.Loggable;
 
 /**
  * Where it all starts.
  * <br>
  * The framework is initialized here with all the required configurations.
-#if (${mockserver} == 'true')
- * It also takes care of the {@link MockContext} initialization and teardown.
-#end
  */
 public abstract class FrameworkBootstrap implements Loggable {
-#if (${mockserver} == 'true')
 
-    /**
-     * Tells {@link MockContext} to initialize the mock server if it is present as a system property.
-     */
     @BeforeSuite
-    public void initializeMockServer() {
-        if (CustomConfiguration.mockServerAddress != null) {
-            MockContext.initializeMockServerClient();
-        }
+    public void initializeGlobalConfigurations() {
+        logger().info("Initialize global configurations");
     }
 
-    /**
-     * Tells {@link MockContext} to reset the mock server data if it is present as a system property.
-     */
     @AfterSuite
-    public void teardownMockServer() {
-        if (CustomConfiguration.mockServerAddress != null) {
-            MockContext.resetMockServerClient();
-        }
+    public void teardownGlobalConfigurations() {
+        logger().info("Teardown global configurations");
     }
-#end
 }

--- a/src/main/resources/archetype-resources/src/test/java/base/MockContext.java
+++ b/src/main/resources/archetype-resources/src/test/java/base/MockContext.java
@@ -4,26 +4,24 @@ import org.mockserver.client.MockServerClient;
 import ${package}.utils.config.CustomConfiguration;
 
 /**
- * Context for objects for mocking purposes.
+ * Holds methods that allow mock external dependency services.
  */
 public class MockContext {
 
     private static MockServerClient mockServerClient;
 
     /**
-     * Initializes the mock server client based on {@link CustomConfiguration} settings.
+     * Instantiates {@link #mockServerClient} object if it needs to be instantiated.
+     * <br>
+     * Synchronized enssures the singleton client instance.
+     *
+     * @return mock server client instance
      */
-    public static void initializeMockServerClient() {
-        MockContext.mockServerClient = new MockServerClient(
-                getMockServerHost(),
-                getMockServerPort());
-    }
+    public static synchronized MockServerClient getMockServerClient() {
+        if (mockServerClient == null) {
+            mockServerClient = new MockServerClient(getMockServerHost(), getMockServerPort());
+        }
 
-    public static void resetMockServerClient() {
-        mockServerClient.reset();
-    }
-
-    public static MockServerClient getMockServerClient() {
         return mockServerClient;
     }
 

--- a/src/main/resources/archetype-resources/src/test/java/tests/ExampleTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/tests/ExampleTest.java
@@ -41,7 +41,7 @@ public class ExampleTest extends BaseTest {
     @Test(description = "Test based on mock server expectations")
     public void testExampleTwo() {
         // This is just an example of the expectation currently being mocked by using MockServer on ${localhost}
-        open("http://mockserver:3000/login");
+        open("http://mockserver:1080/login");
 
         logger().info("Example info log");
         logger().warn("Example warn log");

--- a/src/test/resources/projects/ui_tests/goal.txt
+++ b/src/test/resources/projects/ui_tests/goal.txt
@@ -1,4 +1,5 @@
 test \
 -Dselenide.remote=http://0.0.0.0:4444/wd/hub \
--Dmock.server.address=0.0.0.0:3000 \
--Dlistener=io/company/utils/listeners/MockServerListener.java
+-Dmock.server.address=0.0.0.0:1080 \
+-Dlistener=io/company/utils/listeners/MockServerListener.java \
+-Dselenide.browser=firefox


### PR DESCRIPTION
<!---
Thank you for contributing!
Before submitting a pull request that implements a new functionality or fixing a major bug,
please open an issue first and propose your solution. This way we can discuss before time is 
spent on a solution that may not work for us.

Please check the correct option in the below list and delete the irrelevant one.
For the second option, please fill the issue where the solution has been discussed.
-->

- [x] This is a small change 
- [x] This change has been discussed in issue #19 and the solution has been agreed upon with maintainers.

---

**Description:**

1. Fix firefox integration tests as well as add them to the pipeline
2. Improve mock server initialisation logic
    - Instead of creating the mock server instance before starting the suit, it is now created when the listener calls for the `getMockServerClient()`. This introduces a better performance approach - initialisation is done **only when/if needed**.
